### PR TITLE
Update InputfieldTime.module

### DIFF
--- a/InputfieldTime.module
+++ b/InputfieldTime.module
@@ -98,7 +98,7 @@ class InputfieldTime extends Inputfield
 
     protected function sanitizeValue($value)
     {
-        $value    = trim($value);
+        $value    = trim((string)$value);
         $format   = $this->format;
         $colons   = $this->useColons;
 


### PR DESCRIPTION
Correction for PHP 8 Deprecated: trim(): Passing null to parameter #1 ($string)